### PR TITLE
Improve readme and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [5432],
+	"forwardPorts": [5432],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "/workspace/.devcontainer/setup.sh",
@@ -24,6 +24,8 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
-		"git": "os-provided"
+		"git": "os-provided",
+		// This makes Windows work!
+		"docker-from-docker": "20.10"
 	}
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -11,3 +11,5 @@ sudo apt-get -y install bash-completion postgresql-client
 
 pip3 install -r /workspace/requirements.txt
 ln -s /workspace/.sqlfluff* ~/
+
+cd /workspace && make setup-source-db

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ project in a container.  Once the devcontainer is running, a Postgres container
 will be running , python will be installed, and `dbt` and `sqlfluff` (a
 configured SQL linter) will be ready to go.
 
+The database should be pre-loaded with data meaning that if you run
+`workspace/acme-corp$ dbt run` (`dbt run` from the `/workspace/acme-corp`
+directory) you should not get any errors.  If you do please run `dbt debug` from
+the same directory - it should say "All checks passed!" - if not please let us
+know.
+
+There are two sets of helper commands in the form of "make targets" e.g.
+commands of the form `make <target>` available from two different directories:
+
+- `/workspace` has commands to setup, and reset your database if things aren't
+  working.
+- `/workspace/acme-corp` has commands to run and test `dbt` models as well as
+  lint (check) them for style.
+
+In either directory running `make help` will give you a list of available
+commands.
+
 If you have any difficulties with the above please reach out to us and we will
 do our best to unstick you.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ commands of the form `make <target>` available from two different directories:
 In either directory running `make help` will give you a list of available
 commands.
 
+Additionally, when `dbt` runs the results will reside in a Postgres instance
+running in the devcontainer.  You *can* access them using the Postgres CLI from
+within the devcontainer but we recommend connecting with the client of your
+choice from your computer (rather than from within the devcontainer).  We like
+[Beekeeper Studio](https://www.beekeeperstudio.io/) which should be able to
+connect to the Postgres on `localhost` on port `5432`.
+
 If you have any difficulties with the above please reach out to us and we will
 do our best to unstick you.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ commands of the form `make <target>` available from two different directories:
 In either directory running `make help` will give you a list of available
 commands.
 
+When running `/workspace/acme-corp$ dbt run`, if you get errors which resemble
+the following this indicates the database is not setup correctly.  Running
+`/workspace$ make reset-source-db` should fix the database for you.
+
+```txt
+Database Error in model stg_customers (models/staging/acme/stg_customers.sql)
+  relation "acme.customers" does not exist
+  LINE 13:     from "postgres"."acme"."customers"
+                    ^
+  compiled SQL at target/run/acme_corp/models/staging/acme/stg_customers.sql
+```
+
 Additionally, when `dbt` runs the results will reside in a Postgres instance
 running in the devcontainer.  You *can* access them using the Postgres CLI from
 within the devcontainer but we recommend connecting with the client of your


### PR DESCRIPTION
Over the weekend I met with a candidate using Windows who could not connect to the containerized Postgres running within the devcontainer.  After working through that (by adding `docker-from-docker` it was clear the README skipped other steps as well.  This addresses their pain.