### PR TITLE
bump dbt and associated tooling for dependabot

### DIFF
--- a/acme-corp/packages.yml
+++ b/acme-corp/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 0.8.6
+    version: 0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pip==22.2.2
-dbt-postgres==1.1.1
-sqlfluff==1.0.0
-sqlfluff-templater-dbt==1.0.0
+dbt-postgres==1.2.1
+sqlfluff==1.3.1
+sqlfluff-templater-dbt==1.3.1


### PR DESCRIPTION
Bump a few packages, some of which are co-dependent so dependabot fails on them:

* `dbt-postgres` to `1.2.1`
* `sqlfluff` to `1.3.1` with `sqlfluff-templater-dbt` `1.3.1`
* `dbt_utils` to `0.9.2`